### PR TITLE
Gracefully handle optional codex npm install failures

### DIFF
--- a/install_modules/install_apps.sh
+++ b/install_modules/install_apps.sh
@@ -37,10 +37,12 @@ fi
 apt-get install -y "${packages[@]}"
 
 if command -v npm >/dev/null 2>&1; then
-  log "Installing @openai/codex via npm"
-  npm install -g @openai/codex
+  log "Installing optional @openai/codex via npm"
+  if ! npm install -g @openai/codex; then
+    warn "@openai/codex installation failed; continuing without optional package"
+  fi
 else
-  warn "npm is not available; skipping installation of @openai/codex"
+  warn "npm is not available; skipping installation of optional @openai/codex package"
 fi
 
 if [[ ! -d /opt/pishrink ]]; then


### PR DESCRIPTION
## Summary
- wrap the @openai/codex npm installation in error handling so failures only log a warning
- clarify logging that the @openai/codex package is optional when npm is missing or the install fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d639162a608329adfad2645d01a860