### PR TITLE
Refactor deploy script loop into function

### DIFF
--- a/install_modules/deploy_scripts.sh
+++ b/install_modules/deploy_scripts.sh
@@ -48,16 +48,22 @@ sync_tree() {
   fi
 }
 
-for dir in "$@"; do
-  local_src="$REPO_ROOT/$dir"
-  if [[ ! -d "$local_src" ]]; then
-    warn "Source directory $local_src not found; skipping"
-    continue
-  fi
-  dest="$TARGET_SCRIPTS_DIR/$dir"
-  log "Deploying $dir to $dest"
-  mkdir -p "$dest"
-  sync_tree "$local_src" "$dest"
-  chown -R "$TARGET_USER":"$TARGET_USER" "$dest"
-  find "$dest" -type f -name '*.sh' -exec chmod +x {} +
-done
+deploy_directories() {
+  local local_src dest
+
+  for dir in "$@"; do
+    local_src="$REPO_ROOT/$dir"
+    if [[ ! -d "$local_src" ]]; then
+      warn "Source directory $local_src not found; skipping"
+      continue
+    fi
+    dest="$TARGET_SCRIPTS_DIR/$dir"
+    log "Deploying $dir to $dest"
+    mkdir -p "$dest"
+    sync_tree "$local_src" "$dest"
+    chown -R "$TARGET_USER":"$TARGET_USER" "$dest"
+    find "$dest" -type f -name '*.sh' -exec chmod +x {} +
+  done
+}
+
+deploy_directories "$@"


### PR DESCRIPTION
## Summary
- wrap the deployment loop in a new `deploy_directories` function
- declare local variables for directory paths inside the function
- invoke the new function with the script arguments

## Testing
- `bash -n install_modules/deploy_scripts.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d7dadbc5c88329983ee16dca2aebb7