### PR TITLE
Handle NodeSource nodistro codename for Bookworm

### DIFF
--- a/install_modules/install_apps.sh
+++ b/install_modules/install_apps.sh
@@ -61,7 +61,11 @@ if [[ -f /etc/os-release ]]; then
 fi
 
 if [[ ${nodesource_key_ready} == true ]]; then
-  distro_codename=${VERSION_CODENAME:-${UBUNTU_CODENAME:-nodistro}}
+  if [[ ${VERSION_CODENAME:-} == "bookworm" && ( ${ID:-} == "debian" || ${ID:-} == "raspbian" ) ]]; then
+    distro_codename="nodistro"
+  else
+    distro_codename=${VERSION_CODENAME:-${UBUNTU_CODENAME:-nodistro}}
+  fi
   nodesource_channels=(node_current.x node_23.x node_22.x node_21.x node_20.x)
   nodesource_list="/etc/apt/sources.list.d/nodesource.list"
   nodesource_setup_success=false


### PR DESCRIPTION
## Summary
- ensure the NodeSource repository uses the "nodistro" codename when running on Debian or Raspberry Pi Bookworm so the channel fallback can succeed without 404s

## Testing
- `sudo ./install_rpi5_home.sh` *(fails in container: aborted to avoid massive package installation and due to external repository access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d8490c8a948329a53fdeea7d5648e5